### PR TITLE
feat: set up simple golangci-lint action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,22 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: stable
+    - name: golangci-lint
+      uses: golangci/golangci-lint0action@v6
+      with:
+        version: v1.58


### PR DESCRIPTION
Sets up a simple GitHub Actions CI job to lint / format Go code in this repo.